### PR TITLE
Add random rainbow gradient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,15 @@ async function renderPage(env: Env): Promise<Response> {
 <ul>${list}</ul>
 </div>
 <script>
+function randomRainbowGradient() {
+  const colors = ['#ff0000', '#ff7f00', '#ffff00', '#00ff00', '#0000ff', '#8b00ff'];
+  const angle = Math.floor(Math.random() * 360);
+  const stops = colors.sort(() => Math.random() - 0.5);
+  return `linear-gradient(${angle}deg, ${stops.join(', ')})`;
+}
+document.body.style.background = randomRainbowGradient();
+const btn = document.querySelector("form button[type='submit']");
+if (btn) btn.style.background = randomRainbowGradient();
 document.addEventListener('click', async (e) => {
   const target = e.target;
   if (!(target instanceof Element)) return;


### PR DESCRIPTION
## Summary
- randomize rainbow gradient for the page background and Pin button

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685ff5b3afb48330b2945f7edb15e408