### PR TITLE
Fix gradient template quoting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ function randomRainbowGradient() {
   const colors = ['#ff0000', '#ff7f00', '#ffff00', '#00ff00', '#0000ff', '#8b00ff'];
   const angle = Math.floor(Math.random() * 360);
   const stops = colors.sort(() => Math.random() - 0.5);
-  return `linear-gradient(${angle}deg, ${stops.join(', ')})`;
+  return 'linear-gradient(' + angle + 'deg, ' + stops.join(', ') + ')';
 }
 document.body.style.background = randomRainbowGradient();
 const btn = document.querySelector("form button[type='submit']");


### PR DESCRIPTION
## Summary
- use single quotes for gradient string to avoid nested template quoting

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for '@cloudflare/workers-types')*


------
https://chatgpt.com/codex/tasks/task_e_685ff7290b6883309ba70c57fe5b1613