### PR TITLE
Update API routing for worker-first mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ These steps assume you have [Node.js](https://nodejs.org/) and [wrangler](https:
    ```bash
    npm start
    ```
+   The dev server is configured with `run_worker_first = ["/api/*"]` so that `/api`
+   routes are handled by the Worker.
 
 6. **Deploy**
    ```bash

--- a/public/script.js
+++ b/public/script.js
@@ -34,7 +34,7 @@ function App() {
     const params = new URLSearchParams();
     params.append('phrase', phrase.trim());
     if (emoji) params.append('emoji', emoji);
-    await fetch('/pin', { method: 'POST', body: params });
+    await fetch('/api/pin', { method: 'POST', body: params });
     setPhrase('');
     setEmoji('');
     setPickerOpen(false);
@@ -42,7 +42,7 @@ function App() {
   }
 
   async function inc(id) {
-    await fetch(`/pin/${id}`, { method: 'POST' });
+    await fetch(`/api/pin/${id}`, { method: 'POST' });
     await fetchPins();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 export interface Env {
   DB: D1Database;
-  ASSETS: Fetcher;
 }
 
 async function listPins(env: Env): Promise<Response> {
@@ -18,7 +17,7 @@ export default {
       return listPins(env);
     }
 
-    if (request.method === 'POST' && url.pathname === '/pin') {
+    if (request.method === 'POST' && url.pathname === '/api/pin') {
       const form = await request.formData();
       const phrase = form.get('phrase');
       const emoji = form.get('emoji');
@@ -32,7 +31,7 @@ export default {
       return new Response(null, { status: 201 });
     }
 
-    const match = url.pathname.match(/^\/pin\/(\d+)$/);
+    const match = url.pathname.match(/^\/api\/pin\/(\d+)$/);
     if (request.method === 'POST' && match) {
       const id = Number(match[1]);
       await env.DB.prepare('UPDATE pins SET count = count + 1 WHERE id = ?')
@@ -41,7 +40,6 @@ export default {
       return new Response(null, { status: 204 });
     }
 
-    // fall through to static asset fetching
-    return env.ASSETS.fetch(request);
+    return new Response('Not Found', { status: 404 });
   },
 };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,3 +10,6 @@ binding = "ASSETS"
 binding = "DB"
 database_name = "pin"
 database_id = "5f0cd562-b00b-4716-9844-ab0fa3e943a8"
+
+[dev]
+run_worker_first = ["/api/*"]


### PR DESCRIPTION
## Summary
- prefix dynamic endpoints with `/api`
- return 404 for non-API routes
- enable selective `run_worker_first` in `wrangler.toml`
- note dev server behaviour in README

## Testing
- `npm run`
- `npm start` *(fails: `wrangler` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860cc1f5db48330beee18641c21a6a7