### PR TITLE
Update pin list styling

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -127,15 +127,19 @@ function App() {
           <li key={item.id} className="my-2">
             <a
               href="#"
-              className="block p-4 bg-gray-100 rounded pin-link"
+              className="flex items-center p-4 bg-gray-100 rounded pin-link"
               onClick={(e) => {
                 e.preventDefault();
                 inc(item.id);
               }}
             >
-              {item.emoji && <span className="mr-2">{item.emoji}</span>}
-              {item.phrase + ' '}
-              <span className="text-sm text-gray-500">({item.count})</span>
+              {item.emoji && (
+                <span className="mr-2 flex items-center justify-center w-8 h-8 border rounded">
+                  {item.emoji}
+                </span>
+              )}
+              <span className="flex-grow">{item.phrase}</span>
+              <span className="text-sm text-gray-500 ml-2">({item.count})</span>
             </a>
           </li>
         ))}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export interface Env {
 
 async function listPins(env: Env): Promise<Response> {
   const { results } = await env.DB.prepare(
-    'SELECT id, phrase, emoji, count FROM pins ORDER BY count DESC'
+    'SELECT id, phrase, emoji, count FROM pins ORDER BY count DESC LIMIT 23'
   ).all();
   return Response.json(results);
 }


### PR DESCRIPTION
## Summary
- limit pin API results to 23 entries
- show emoji in a bordered square
- display pins in API order without client-side modifications

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: wrangler not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860d5c728e4833091cfa4164c78b5da